### PR TITLE
Conditonally fetch data based on environment

### DIFF
--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,10 +1,27 @@
+require('dotenv').config // to load environment variables
 import { Todo } from "@/lib/drizzle";
 
 const getData = async () => {
+
+    //  retrieving the url of deployed version
+    const deployedURL = process.env.REACT_APP_URL
+
+    // will use this variable to condtionally set absolute url path
+    let isLocalHost: boolean = false
+
+    // checking localhost using window object since this code will be rendered on server and window object dosent exist on server
+    if (typeof window === undefined) {
+        isLocalHost = true
+    }
+
+    // setting site URL using ternary operator
+    const siteUrl = isLocalHost ? "http://localhost:3000" : deployedURL
+
     try {
-        const res = await fetch("http://127.0.0.1:3000/api/todo", {
+        // attaching the api path to site URL
+        const res = await fetch(`${siteUrl}/api/todo`, {
             method: "GET",
-            cache:"no-store",
+            cache: "no-store",
             headers: {
                 "Content-Type": "application/json"
             }


### PR DESCRIPTION
### Fetch request should also work on the deployed version

The current code will not work on the vercel deployed site

Fetch request can not be used like this because, in server-side components, absolute paths are [required](https://github.com/vercel/next.js/issues/48344#issuecomment-1507068100)
`const res = await fetch("/api/todo")`

Hence we have to do something like this
`const res = await fetch("absolute/path/api/todo")`


This leads to the issue:
## How to give an absolute path for both the localhost and vercel deployed version

We can do this by conditionally checking the environment and then assigning the absolute path

The idea is to check the environment using the window object because it is a client-side object and this component is server-side

When Vercel will be building our project this component will be rendered on the server and `window` will be undefined

**Other requirements**
- Set up an environment variable `REACT_APP_URL` from the vercel dashboard (value should be the URL of deployed version)
- Pull it in the repository using `vercel env pull .env.development.local`
- Re-deoply to vercel


